### PR TITLE
require node 16 due to usage of adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "optionalDependencies": {
     "canvas": "^2.11.2"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3"
   },


### PR DESCRIPTION
adapter-core 3.0.0 is known to fail with node 14 as npm 6 does not install peerDependencies.
So this adapter must require node 16 or newer